### PR TITLE
Use tag provided by publish event

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: ${{matrix.node-version}}
       - run: npm ci
-      - run: npm version from-git --no-git-tag-version
+      - run: npm version $GITHUB_REF --no-git-tag-version
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
This pull request fixes an issue where the publish workflow could not read the git tag.